### PR TITLE
chore(deps): bump versions for gha

### DIFF
--- a/.github/workflows/ga4_etl.yml
+++ b/.github/workflows/ga4_etl.yml
@@ -14,18 +14,18 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests pandas google-cloud-bigquery pyarrow google-analytics-data
         
     - name: Authorize google cloud 
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.GOOGLE_ANALYTICS_API_SERVICE_ACCOUNT}}'
     - name: Run github etl script        

--- a/.github/workflows/gh_insights_etl.yml
+++ b/.github/workflows/gh_insights_etl.yml
@@ -14,18 +14,18 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests pandas flatten_json google-cloud-bigquery pyarrow
         
     - name: Authorize google cloud 
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: '${{ secrets.GOOGLE_ANALYTICS_API_SERVICE_ACCOUNT}}'
         

--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -8,8 +8,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v4
-            with:
-                ref: 'keep-alive'
-          - uses: gautamkrishnar/keepalive-workflow@v1
+          - uses: gautamkrishnar/keepalive-workflow@v2
             with:
                 time_elapsed: 50

--- a/.github/workflows/run_bigquery_queries.yml
+++ b/.github/workflows/run_bigquery_queries.yml
@@ -9,12 +9,12 @@ jobs:
   dry-run-queries:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           
       - name: Install dependencies
         run: |
@@ -22,13 +22,13 @@ jobs:
           pip install requests pandas google-cloud-bigquery pyarrow google-analytics-data
           
       - name: Authorize google cloud 
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GOOGLE_ANALYTICS_API_SERVICE_ACCOUNT}}'
 
       # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'      
+        uses: 'google-github-actions/setup-gcloud@v2'      
         
       - name: List SQL Files
         run: |


### PR DESCRIPTION
Several gha runs have deprecation warnings. This PR updates all of them to latest versions. We may want to consider dependabot.